### PR TITLE
Update test_full config with new samplesheet containing s3 paths

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,11 +15,6 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data
-    //input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/multiplesequencealign/samplesheet/v1.0/samplesheet_test.csv'
-    input  = "./assets/samplesheet_full.csv"
+    input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/multiplesequencealign/samplesheet/v1.0/samplesheet_full.csv'
     tools  = 'https://raw.githubusercontent.com/nf-core/test-datasets/multiplesequencealign/toolsheet/v1.0/toolsheet_full.csv'
-
-
-    // Output directory
-    outdir = "./outdir/"
 }


### PR DESCRIPTION
The samplesheet used in the `test_full.config` has been updated on [this](https://github.com/nf-core/test-datasets/pull/1162) PR to test-datasets.

Closes #82 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] `CHANGELOG.md` is updated.
