### PR TITLE
Use same ubuntu version for all process and hopefully improve process tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ Initial release of nf-core/multiplesequencealign, created with the [nf-core](htt
 - [[#89](https://github.com/nf-core/multiplesequencealign/issues/89)] - Add collection of plddt metrics in stats subworkflow.
 - [[#96](https://github.com/nf-core/multiplesequencealign/issues/96)] - Add collection of number of gaps in eval subworkflow.
 - [[#84](https://github.com/nf-core/multiplesequencealign/issues/84)] - Update Metromap
-- [[#139](https://github.com/nf-core/multiplesequencealign/pull/139)] - Add Foldmason
+- [[#139](https://github.com/nf-core/multiplesequencealign/pull/139)] - Add Foldmason.
+- [[#146](https://github.com/nf-core/multiplesequencealign/pull/146)] - Only show additional process tags when they exists and use the same ubuntu version in all modules.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,18 @@ Initial release of nf-core/multiplesequencealign, created with the [nf-core](htt
 
 ### `Added`
 
-- [[#29](https://github.com/nf-core/multiplesequencealign/issues/29)] - Add FAMSA_ALIGN module
-- [[#38](https://github.com/nf-core/multiplesequencealign/issues/38)] - Add FAMSA_GUIDETREE module
-- [[#42](https://github.com/nf-core/multiplesequencealign/issues/42)] - Add MAFFT module
-- [[#51](https://github.com/nf-core/multiplesequencealign/issues/51)] - Add CLUSTALO module
-- [[#41](https://github.com/nf-core/multiplesequencealign/issues/41)] - Add KALIGN module
-- [[#48](https://github.com/nf-core/multiplesequencealign/issues/48)] - Integrate NF-VALIDATION PLUGIN
+- [[#29](https://github.com/nf-core/multiplesequencealign/issues/29)] - Add FAMSA_ALIGN module.
+- [[#38](https://github.com/nf-core/multiplesequencealign/issues/38)] - Add FAMSA_GUIDETREE module.
+- [[#42](https://github.com/nf-core/multiplesequencealign/issues/42)] - Add MAFFT module.
+- [[#51](https://github.com/nf-core/multiplesequencealign/issues/51)] - Add CLUSTALO module.
+- [[#41](https://github.com/nf-core/multiplesequencealign/issues/41)] - Add KALIGN module.
+- [[#48](https://github.com/nf-core/multiplesequencealign/issues/48)] - Integrate NF-VALIDATION PLUGIN.
 - [[#45](https://github.com/nf-core/multiplesequencealign/issues/45)] - Add module LearnMSA
-- [[#35](https://github.com/nf-core/multiplesequencealign/issues/35)] - Add module Tcoffee_align
-- [[#60](https://github.com/nf-core/multiplesequencealign/issues/60)] - Add module Tcoffee3D_align and handle structures input
-- [[#35](https://github.com/nf-core/multiplesequencealign/issues/35)] - Add module MUSCLE5_SUPER5
+- [[#35](https://github.com/nf-core/multiplesequencealign/issues/35)] - Add module Tcoffee_align.
+- [[#60](https://github.com/nf-core/multiplesequencealign/issues/60)] - Add module Tcoffee3D_align and handle structures input.
+- [[#35](https://github.com/nf-core/multiplesequencealign/issues/35)] - Add module MUSCLE5_SUPER5.
 - [[#59](https://github.com/nf-core/multiplesequencealign/issues/59)] - Add support for passing structure template in samplesheet.
-- [[#77](https://github.com/nf-core/multiplesequencealign/issues/77)] - Add module zip
+- [[#77](https://github.com/nf-core/multiplesequencealign/issues/77)] - Add module zip.
 - [[#93](https://github.com/nf-core/multiplesequencealign/pull/93)] - Add multiqc basic support. Add custom params validation. Add basic shiny app.
 - [[#100](https://github.com/nf-core/multiplesequencealign/pull/100)] - Add support for optional stats and evals. Clean tests.
 - [[#110](https://github.com/nf-core/multiplesequencealign/issues/110)] - Add Readme documentation. Add nf-test for the pipeline.
@@ -30,7 +30,7 @@ Initial release of nf-core/multiplesequencealign, created with the [nf-core](htt
 - [[#90](https://github.com/nf-core/multiplesequencealign/issues/90)] - Add TCS evaluation metric.
 - [[#89](https://github.com/nf-core/multiplesequencealign/issues/89)] - Add collection of plddt metrics in stats subworkflow.
 - [[#96](https://github.com/nf-core/multiplesequencealign/issues/96)] - Add collection of number of gaps in eval subworkflow.
-- [[#84](https://github.com/nf-core/multiplesequencealign/issues/84)] - Update Metromap
+- [[#84](https://github.com/nf-core/multiplesequencealign/issues/84)] - Update Metromap.
 - [[#139](https://github.com/nf-core/multiplesequencealign/pull/139)] - Add Foldmason.
 - [[#146](https://github.com/nf-core/multiplesequencealign/pull/146)] - Only show additional process tags when they exists and use the same ubuntu version in all modules.
 
@@ -43,8 +43,8 @@ Initial release of nf-core/multiplesequencealign, created with the [nf-core](htt
 - [[#80](https://github.com/nf-core/multiplesequencealign/pull/80)] - Update modules versions from nf-core tools with nf-test.
 - [[#32](https://github.com/nf-core/multiplesequencealign/issues/32)] - Update Stats workflow with nf-core modules for merging.
 - [[#81](https://github.com/nf-core/multiplesequencealign/pull/81)] - Update Eval workflow with nf-core modules for merging.
-- [[#111](https://github.com/nf-core/multiplesequencealign/pull/111)] - Fix linting warnings (mostly versions)
-- [[#134](https://github.com/nf-core/multiplesequencealign/pull/134)] - Code revision for release preparation
+- [[#111](https://github.com/nf-core/multiplesequencealign/pull/111)] - Fix linting warnings (mostly versions).
+- [[#134](https://github.com/nf-core/multiplesequencealign/pull/134)] - Code revision for release preparation.
 - [[#138](https://github.com/nf-core/multiplesequencealign/pull/138)] - MultiQC as nf-core module and fix visualization.
 
 ### `Dependencies`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -128,7 +128,7 @@
                 [
                     "${meta.id}",
                     meta.tree ? "tree: ${meta.tree}" : "",
-                    ${args_tree} ? "argstree: ${args_tree}" : "",
+                    meta.args_tree ? "argstree: ${meta.args_tree}" : "",
                     meta.args_aligner ? "args: ${meta.args_aligner}" : ""
                 ].join(' ').trim()
             }
@@ -148,7 +148,7 @@
                 [
                     "${meta.id}",
                     meta.tree ? "tree: ${meta.tree}" : "",
-                    ${args_tree} ? "argstree: ${args_tree}" : "",
+                    meta.args_tree ? "argstree: ${meta.args_tree}" : "",
                     meta.args_aligner ? "args: ${meta.args_aligner}" : ""
                 ].join(' ').trim()
             }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -67,8 +67,13 @@
         // Tree building
         //
 
-        withName: "FAMSA_GUIDETREE"{
-            tag = { "${meta.id} args:${meta.args_tree}" }
+        withName: "FAMSA_GUIDETREE" {
+            tag = { 
+                    [
+                        "${meta.id}",
+                        meta.args_tree ? "args: ${meta.args_tree}" : ""
+                    ].join(' ').trim()
+                }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}" }
             ext.args = { "${meta.args_tree}" == "null" ? '' : "${meta.args_tree}" }
             publishDir = [
@@ -78,8 +83,14 @@
             ]
         }
 
-        withName: "CLUSTALO_GUIDETREE"{
-            tag = { "${meta.id} args:${meta.args_tree}" }
+        withName: "CLUSTALO_GUIDETREE" {
+            tag = { 
+                    [
+                        "${meta.id}",
+                        meta.args_tree ? "args: ${meta.args_tree}" : ""
+                    ].join(' ').trim()
+                }
+            // tag = { "${meta.id} args:${meta.args_tree}" }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}" }
             ext.args   = { "${meta.args_tree}" == "null" ? '' : "${meta.args_tree}" }
             publishDir = [
@@ -89,8 +100,14 @@
             ]
         }
 
-        withName: "MAGUS_GUIDETREE"{
-            tag = { "${meta.id} args:${meta.args_tree}" }
+        withName: "MAGUS_GUIDETREE" {
+            tag = { 
+                    [
+                        "${meta.id}",
+                        meta.args_tree ? "args: ${meta.args_tree}" : ""
+                    ].join(' ').trim()
+                }
+            // tag = { "${meta.id} args:${meta.args_tree}" }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}" }
             ext.args   = { "${meta.args_tree}" == "null" ? '' : "${meta.args_tree}" }
             publishDir = [
@@ -108,8 +125,17 @@
             ext.prefix = { "${meta.id}" }
         }
 
-        withName: "CLUSTALO_ALIGN|FAMSA_ALIGN|LEARNMSA_ALIGN|MAFFT|MAGUS_ALIGN|MUSCLE5_SUPER5|REGRESSIVE|TCOFFEE_ALIGN|TCOFFEE3D_ALIGN|FOLDMASON_EASYMSA"{
-            tag = { "${meta.id} tree:${meta.tree} argstree:${args_tree} args:${meta.args_aligner}" }
+        withName: "CLUSTALO_ALIGN|FAMSA_ALIGN|LEARNMSA_ALIGN|MAFFT|MAGUS_ALIGN|MUSCLE5_SUPER5|REGRESSIVE|TCOFFEE_ALIGN|TCOFFEE3D_ALIGN|FOLDMASON_EASYMSA" {
+            tag = { 
+                    [
+                        "${meta.id}",
+                        meta.tree ? "tree: ${meta.tree}" : "",
+                        ${args_tree} ? "argstree: ${args_tree}" : "",
+                        meta.args_aligner ? "args: ${meta.args_aligner}" : ""
+                    ].join(' ').trim()
+                }
+                    
+                    // argstree:${args_tree} args:${meta.args_aligner}" }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}" }
             ext.args = { "${meta.args_aligner}" == "null" ? '' : "${meta.args_aligner}" }
             if(params.skip_compression){
@@ -121,8 +147,16 @@
             }
         }
 
-        withName: "MTMALIGN_ALIGN"{
-            tag = { "${meta.id} tree:${meta.tree} argstree:${args_tree} args:${meta.args_aligner}" }
+        withName: "MTMALIGN_ALIGN" {
+            // tag = { "${meta.id} tree:${meta.tree} argstree:${args_tree} args:${meta.args_aligner}" }
+            tag = { 
+                    [
+                        "${meta.id}",
+                        meta.tree ? "tree: ${meta.tree}" : "",
+                        ${args_tree} ? "argstree: ${args_tree}" : "",
+                        meta.args_aligner ? "args: ${meta.args_aligner}" : ""
+                    ].join(' ').trim() 
+                }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}" }
             ext.args = { "${meta.args_aligner}" == "null" ? '' : "${meta.args_aligner}" }
             if(params.skip_compression){

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -68,7 +68,7 @@
         //
 
         withName: "FAMSA_GUIDETREE" {
-            tag = { 
+            tag = {
                 [
                     "${meta.id}",
                     meta.args_tree ? "args: ${meta.args_tree}" : ""
@@ -84,7 +84,7 @@
         }
 
         withName: "CLUSTALO_GUIDETREE" {
-            tag = { 
+            tag = {
                 [
                     "${meta.id}",
                     meta.args_tree ? "args: ${meta.args_tree}" : ""
@@ -100,7 +100,7 @@
         }
 
         withName: "MAGUS_GUIDETREE" {
-            tag = { 
+            tag = {
                 [
                     "${meta.id}",
                     meta.args_tree ? "args: ${meta.args_tree}" : ""
@@ -124,7 +124,7 @@
         }
 
         withName: "CLUSTALO_ALIGN|FAMSA_ALIGN|LEARNMSA_ALIGN|MAFFT|MAGUS_ALIGN|MUSCLE5_SUPER5|REGRESSIVE|TCOFFEE_ALIGN|TCOFFEE3D_ALIGN|FOLDMASON_EASYMSA" {
-            tag = { 
+            tag = {
                 [
                     "${meta.id}",
                     meta.tree ? "tree: ${meta.tree}" : "",
@@ -144,13 +144,13 @@
         }
 
         withName: "MTMALIGN_ALIGN" {
-            tag = { 
+            tag = {
                 [
                     "${meta.id}",
                     meta.tree ? "tree: ${meta.tree}" : "",
                     ${args_tree} ? "argstree: ${args_tree}" : "",
                     meta.args_aligner ? "args: ${meta.args_aligner}" : ""
-                ].join(' ').trim() 
+                ].join(' ').trim()
             }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}" }
             ext.args = { "${meta.args_aligner}" == "null" ? '' : "${meta.args_aligner}" }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -16,7 +16,7 @@
         // Statistics about the input sequences
         //
 
-        withName: "CALCULATE_SEQSTATS"{
+        withName: "CALCULATE_SEQSTATS" {
             publishDir = [
                 path: { "${params.outdir}/summary/stats/sequences/seqstats" },
                 mode: params.publish_dir_mode,
@@ -24,7 +24,7 @@
             ]
         }
 
-        withName: "CONCAT_SEQSTATS"{
+        withName: "CONCAT_SEQSTATS" {
             ext.prefix = { "summary_seqstats" }
         }
 
@@ -36,7 +36,7 @@
             ]
         }
 
-        withName: "CONCAT_PLDDT"{
+        withName: "CONCAT_PLDDT" {
             ext.prefix = { "summary_plddt" }
         }
 
@@ -49,7 +49,7 @@
             ]
         }
 
-        withName: "CONCAT_SIMSTATS"{
+        withName: "CONCAT_SIMSTATS" {
             ext.prefix = { "summary_simstats" }
         }
 
@@ -69,11 +69,11 @@
 
         withName: "FAMSA_GUIDETREE" {
             tag = { 
-                    [
-                        "${meta.id}",
-                        meta.args_tree ? "args: ${meta.args_tree}" : ""
-                    ].join(' ').trim()
-                }
+                [
+                    "${meta.id}",
+                    meta.args_tree ? "args: ${meta.args_tree}" : ""
+                ].join(' ').trim()
+            }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}" }
             ext.args = { "${meta.args_tree}" == "null" ? '' : "${meta.args_tree}" }
             publishDir = [
@@ -85,12 +85,11 @@
 
         withName: "CLUSTALO_GUIDETREE" {
             tag = { 
-                    [
-                        "${meta.id}",
-                        meta.args_tree ? "args: ${meta.args_tree}" : ""
-                    ].join(' ').trim()
-                }
-            // tag = { "${meta.id} args:${meta.args_tree}" }
+                [
+                    "${meta.id}",
+                    meta.args_tree ? "args: ${meta.args_tree}" : ""
+                ].join(' ').trim()
+            }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}" }
             ext.args   = { "${meta.args_tree}" == "null" ? '' : "${meta.args_tree}" }
             publishDir = [
@@ -102,12 +101,11 @@
 
         withName: "MAGUS_GUIDETREE" {
             tag = { 
-                    [
-                        "${meta.id}",
-                        meta.args_tree ? "args: ${meta.args_tree}" : ""
-                    ].join(' ').trim()
-                }
-            // tag = { "${meta.id} args:${meta.args_tree}" }
+                [
+                    "${meta.id}",
+                    meta.args_tree ? "args: ${meta.args_tree}" : ""
+                ].join(' ').trim()
+            }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}" }
             ext.args   = { "${meta.args_tree}" == "null" ? '' : "${meta.args_tree}" }
             publishDir = [
@@ -121,21 +119,19 @@
         // Alignment
         //
 
-        withName: "CREATE_TCOFFEETEMPLATE"{
+        withName: "CREATE_TCOFFEETEMPLATE" {
             ext.prefix = { "${meta.id}" }
         }
 
         withName: "CLUSTALO_ALIGN|FAMSA_ALIGN|LEARNMSA_ALIGN|MAFFT|MAGUS_ALIGN|MUSCLE5_SUPER5|REGRESSIVE|TCOFFEE_ALIGN|TCOFFEE3D_ALIGN|FOLDMASON_EASYMSA" {
             tag = { 
-                    [
-                        "${meta.id}",
-                        meta.tree ? "tree: ${meta.tree}" : "",
-                        ${args_tree} ? "argstree: ${args_tree}" : "",
-                        meta.args_aligner ? "args: ${meta.args_aligner}" : ""
-                    ].join(' ').trim()
-                }
-                    
-                    // argstree:${args_tree} args:${meta.args_aligner}" }
+                [
+                    "${meta.id}",
+                    meta.tree ? "tree: ${meta.tree}" : "",
+                    ${args_tree} ? "argstree: ${args_tree}" : "",
+                    meta.args_aligner ? "args: ${meta.args_aligner}" : ""
+                ].join(' ').trim()
+            }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}" }
             ext.args = { "${meta.args_aligner}" == "null" ? '' : "${meta.args_aligner}" }
             if(params.skip_compression){
@@ -148,15 +144,14 @@
         }
 
         withName: "MTMALIGN_ALIGN" {
-            // tag = { "${meta.id} tree:${meta.tree} argstree:${args_tree} args:${meta.args_aligner}" }
             tag = { 
-                    [
-                        "${meta.id}",
-                        meta.tree ? "tree: ${meta.tree}" : "",
-                        ${args_tree} ? "argstree: ${args_tree}" : "",
-                        meta.args_aligner ? "args: ${meta.args_aligner}" : ""
-                    ].join(' ').trim() 
-                }
+                [
+                    "${meta.id}",
+                    meta.tree ? "tree: ${meta.tree}" : "",
+                    ${args_tree} ? "argstree: ${args_tree}" : "",
+                    meta.args_aligner ? "args: ${meta.args_aligner}" : ""
+                ].join(' ').trim() 
+            }
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}" }
             ext.args = { "${meta.args_aligner}" == "null" ? '' : "${meta.args_aligner}" }
             if(params.skip_compression){
@@ -170,7 +165,7 @@
 
         }
 
-        withName:"PIGZ_COMPRESS"{
+        withName:"PIGZ_COMPRESS" {
             publishDir = [
                 path: { "${params.outdir}/alignment/${meta.id}" },
                 mode: params.publish_dir_mode,
@@ -182,21 +177,21 @@
         // Alignment evaluation
         //
 
-        withName: 'PARSE_IRMSD'{
+        withName: 'PARSE_IRMSD' {
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}_irmsd" }
         }
 
-        withName: 'TCOFFEE_ALNCOMPARE_SP'{
+        withName: 'TCOFFEE_ALNCOMPARE_SP' {
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}_sp" }
             ext.args = "-compare_mode sp"
         }
 
-        withName: 'TCOFFEE_ALNCOMPARE_TC'{
+        withName: 'TCOFFEE_ALNCOMPARE_TC' {
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}_tc" }
             ext.args = "-compare_mode tc"
         }
 
-        withName: 'TCOFFEE_IRMSD'{
+        withName: 'TCOFFEE_IRMSD' {
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}_irmsd" }
             publishDir = [
                 path: { "${params.outdir}/evaluation/${task.process.tokenize(':')[-1].toLowerCase()}" },
@@ -205,31 +200,31 @@
             ]
         }
 
-        withName: "CALC_GAPS"{
+        withName: "CALC_GAPS" {
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}_gaps" }
         }
 
-        withName: "CONCAT_IRMSD"{
+        withName: "CONCAT_IRMSD" {
             ext.prefix = { "summary_irmsd" }
         }
 
-        withName: "CONCAT_GAPS"{
+        withName: "CONCAT_GAPS" {
             ext.prefix = { "summary_gaps" }
         }
 
-        withName: "CONCAT_SP"{
+        withName: "CONCAT_SP" {
             ext.prefix = { "summary_sp" }
         }
 
-        withName: "CONCAT_TC"{
+        withName: "CONCAT_TC" {
             ext.prefix = { "summary_tc" }
         }
 
-        withName: "CONCAT_TCS"{
+        withName: "CONCAT_TCS" {
             ext.prefix = { "summary_tcs" }
         }
 
-        withName: 'TCOFFEE_TCS'{
+        withName: 'TCOFFEE_TCS' {
             ext.prefix = { "${meta.id}_${meta.tree}-args-${meta.argstree_clean}_${meta.aligner}-args-${meta.args_aligner_clean}_tcs" }
             publishDir = [
                 path: { "${params.outdir}/evaluation/${task.process.tokenize(':')[-1].toLowerCase()}" },
@@ -238,7 +233,7 @@
             ]
         }
 
-        withName: "MERGE_EVAL"{
+        withName: "MERGE_EVAL" {
             ext.prefix = { "complete_summary_eval" }
             ext.args = "-f 1,2,3,4,5,6,7 -O"
             publishDir = [
@@ -248,7 +243,7 @@
             ]
         }
 
-        withName: "MERGE_STATS_EVAL"{
+        withName: "MERGE_STATS_EVAL" {
             ext.prefix = { "complete_summary_stats_eval" }
             ext.args = "-f 1 -O"
             publishDir = [

--- a/modules/local/calculate_gaps.nf
+++ b/modules/local/calculate_gaps.nf
@@ -3,8 +3,8 @@ process CALC_GAPS {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-    'nf-core/ubuntu:20.04' }"
+    'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+    'nf-core/ubuntu:22.04' }"
 
     input:
     tuple val(meta), path(msa)

--- a/modules/local/create_tcoffee_template.nf
+++ b/modules/local/create_tcoffee_template.nf
@@ -3,8 +3,8 @@ process CREATE_TCOFFEETEMPLATE {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-    'nf-core/ubuntu:20.04' }"
+    'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+    'nf-core/ubuntu:22.04' }"
 
     input:
     tuple val(meta), val(suffix), path(accessory_informations)

--- a/modules/local/extract_plddt.nf
+++ b/modules/local/extract_plddt.nf
@@ -3,8 +3,8 @@ process EXTRACT_PLDDT {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-    'nf-core/ubuntu:20.04' }"
+    'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+    'nf-core/ubuntu:22.04' }"
 
     input:
     tuple val(meta), path(structures)

--- a/modules/local/parse_sim.nf
+++ b/modules/local/parse_sim.nf
@@ -3,8 +3,8 @@ process PARSE_SIM {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-    'nf-core/ubuntu:20.04' }"
+    'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+    'nf-core/ubuntu:22.04' }"
 
     input:
     tuple val(meta), path(infile)

--- a/modules/local/prepare_shiny.nf
+++ b/modules/local/prepare_shiny.nf
@@ -3,8 +3,8 @@ process PREPARE_SHINY {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-    'nf-core/ubuntu:20.04' }"
+    'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+    'nf-core/ubuntu:22.04' }"
 
     input:
     tuple val(meta), path(table)


### PR DESCRIPTION
This PR includes:

* Local modules have been updated to use the same version of ubuntu (`22.04`) as the nf-core modules to only download one image.
* The tagging of the processes has been changed and now only if the additional `tree`, `args`, `argstree` or `args_aligner` are populated they are shown by the `tag` otherwise they are not shown anymore.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
