### PR TITLE
Fix link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For more details about the output files and reports, please refer to the
 
 ## Extending the pipeline
 
-For details on how to add your favourite guide tree, MSA or evaluation step in nf-core/multiplesequencealign please refer to the [extending documentation](https://github.com/luisas/multiplesequencealign/blob/luisa_patch/docs/extending.md).
+For details on how to add your favourite guide tree, MSA or evaluation step in nf-core/multiplesequencealign please refer to the [extending documentation](docs/extending.md).
 
 ## Credits
 


### PR DESCRIPTION
Just noticed the old link to the extending docs no longer works, changed it to a relative link.