### PR TITLE
minifix shiny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Initial release of nf-core/multiplesequencealign, created with the [nf-core](htt
 - [[#134](https://github.com/nf-core/multiplesequencealign/pull/134)] - Code revision for release preparation.
 - [[#138](https://github.com/nf-core/multiplesequencealign/pull/138)] - MultiQC as nf-core module and fix visualization.
 - [[#152](https://github.com/nf-core/multiplesequencealign/pull/152)] - Ignore kalign error 132 and print a warning (incompatibility with some CPU types).
+- [[#153](https://github.com/nf-core/multiplesequencealign/pull/153)] - Fix time parser in shiny app.
 
 ### `Dependencies`
 

--- a/bin/shiny_app/shiny_app_merge_score_and_trace.py
+++ b/bin/shiny_app/shiny_app_merge_score_and_trace.py
@@ -3,18 +3,19 @@ import re
 
 def convert_time(time_str):
     # Regular expression to match the time components
-    pattern = re.compile(r'((?P<hours>\d+)h)?\s*((?P<minutes>\d+)m)?\s*((?P<seconds>\d+)s)?\s*((?P<milliseconds>\d+)ms)?')
+    pattern = re.compile(r'((?P<hours>\d+(\.\d+)?)h)?\s*((?P<minutes>\d+(\.\d+)?)m)?\s*((?P<seconds>\d+(\.\d+)?)s)?\s*((?P<milliseconds>\d+(\.\d+)?)ms)?')
     match = pattern.fullmatch(time_str.strip())
 
     if not match:
+        print(time_str)
         raise ValueError("Time string is not in the correct format")
 
     time_components = match.groupdict(default='0')
 
-    hours = int(time_components['hours'])
-    minutes = int(time_components['minutes'])
-    seconds = int(time_components['seconds'])
-    milliseconds = int(time_components['milliseconds'])
+    hours = float(time_components['hours'])
+    minutes = float(time_components['minutes'])
+    seconds = float(time_components['seconds'])
+    milliseconds = float(time_components['milliseconds'])
 
     # Convert everything to minutes
     total_minutes = (hours * 60) + minutes + (seconds / 60) + (milliseconds / 60000)


### PR DESCRIPTION
## PR checklist

time measuerments can be in float format - updated in the parsing of the shiny app

- [x This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/multiplesequencealign/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/multiplesequencealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
